### PR TITLE
Bug fix: Overlapping display of transaction labels

### DIFF
--- a/src/balanceEntitiesOverPlotLines.js
+++ b/src/balanceEntitiesOverPlotLines.js
@@ -13,6 +13,10 @@ const isOverlappingLine = (line, begin, end) => {
         if (end > otherBegin && end < otherEnd) {
             return true;
         }
+
+        if (begin - otherBegin < 250) {
+            return true;
+        }
     }
 
     return false;

--- a/src/components/style/TransactionPlotItem.scss
+++ b/src/components/style/TransactionPlotItem.scss
@@ -15,14 +15,23 @@
             // left and width are set by script
             background: $PerformrRunnerResultGraph_transactionPlotColorOdd;
             text-align: center;
+            white-space: nowrap; // Prevent time from writing to next line
+            overflow: hidden;
+            text-overflow: ellipsis;
             border: none;
             padding: 0;
             color: inherit;
             font: inherit;
             cursor: pointer;
 
+            &:hover {
+                overflow: visible;
+                z-index: 1;
+            }
+
             > .title {
                 font-weight: bold;
+                background-color: inherit;
 
                 &:after {
                     content: ": ";
@@ -30,7 +39,7 @@
             }
 
             > .time {
-
+                background-color: inherit;
             }
         }
     }

--- a/test/balanceEntitiesOverPlotLines.test.js
+++ b/test/balanceEntitiesOverPlotLines.test.js
@@ -15,22 +15,22 @@ describe('balanceEntitiesOverPlotLines', () => {
             {
                 id: 0,
                 timing: {
-                    begin: {time: 10},
-                    end: {time: 20},
+                    begin: {time: 1000},
+                    end: {time: 2000},
                 },
             },
             {
                 id: 1,
                 timing: {
-                    begin: {time: 20},
-                    end: {time: 30},
+                    begin: {time: 2000},
+                    end: {time: 3000},
                 },
             },
             {
                 id: 2,
                 timing: {
-                    begin: {time: 1000},
-                    end: {time: 1001},
+                    begin: {time: 10000},
+                    end: {time: 10010},
                 },
             },
         ]);
@@ -51,22 +51,22 @@ describe('balanceEntitiesOverPlotLines', () => {
             {
                 id: 0,
                 timing: {
-                    begin: {time: 10},
-                    end: {time: 20},
+                    begin: {time: 1000},
+                    end: {time: 2000},
                 },
             },
             {
                 id: 1,
                 timing: {
-                    begin: {time: 19},
-                    end: {time: 30},
+                    begin: {time: 1900},
+                    end: {time: 3000},
                 },
             },
             {
                 id: 2,
                 timing: {
-                    begin: {time: 1000},
-                    end: {time: 1001},
+                    begin: {time: 10000},
+                    end: {time: 10010},
                 },
             },
         ]);
@@ -89,29 +89,29 @@ describe('balanceEntitiesOverPlotLines', () => {
             {
                 id: 0,
                 timing: {
-                    begin: {time: 10},
-                    end: {time: 20},
+                    begin: {time: 1000},
+                    end: {time: 2000},
                 },
             },
             {
                 id: 1,
                 timing: {
-                    begin: {time: 19},
-                    end: {time: 30},
+                    begin: {time: 1900},
+                    end: {time: 3000},
                 },
             },
             {
                 id: 2,
                 timing: {
-                    begin: {time: 1000},
-                    end: {time: 1100},
+                    begin: {time: 10000},
+                    end: {time: 11000},
                 },
             },
             {
                 id: 3,
                 timing: {
-                    begin: {time: 900},
-                    end: {time: 1001},
+                    begin: {time: 9000},
+                    end: {time: 10010},
                 },
             },
         ]);
@@ -129,4 +129,35 @@ describe('balanceEntitiesOverPlotLines', () => {
         assert.strictEqual(result.getIn([0, 1, 'id']), 2);
         assert.strictEqual(result.getIn([1, 1, 'id']), 3);
     });
+
+    it('should place next entity on a new line if difference between consecutive beginnings is less than 250ms', () => {
+        const entities = fromJS([
+            {
+                id: 0,
+                timing: {
+                    begin: {time: 1000},
+                    end: {time: 1100},
+                },
+            },
+            {
+                id: 1,
+                timing: {
+                    begin: {time: 1249},
+                    end: {time: 3000},
+                },
+            },
+        ]);
+
+        const result = balanceEntitiesOverPlotLines(entities);
+
+        assert(List.isList(result));
+        assert.strictEqual(result.size, 2);
+        assert(List.isList(result.get(0)));
+        assert.strictEqual(result.get(0).size, 1);
+        assert(List.isList(result.get(1)));
+        assert.strictEqual(result.get(1).size, 1);
+        assert.strictEqual(result.getIn([0, 0, 'id']), 0);
+        assert.strictEqual(result.getIn([1, 0, 'id']), 1);
+    });
+
 });


### PR DESCRIPTION
+ Hide overflowed text in transaction title
+ Hover to display the overflowed text
+ Display very short transactions on separate rows for clarity