### PR TITLE
Improve formatting of request and response headers

### DIFF
--- a/src/components/EventMetaDataTable.jsx
+++ b/src/components/EventMetaDataTable.jsx
@@ -74,7 +74,7 @@ export default class EventMetaDataTable extends PureComponent {
                         {value.map((map, i) => (
                             <li className='headerListItem' key={i}>
                                 <span className="key">{map.get('name') + ': '}</span>
-                                {map.get('value')}
+                                <span className="value">{map.get('value')}</span>
                             </li>
                         ))
                         }

--- a/src/components/EventMetaDataTable.jsx
+++ b/src/components/EventMetaDataTable.jsx
@@ -67,7 +67,7 @@ export default class EventMetaDataTable extends PureComponent {
             return String(value);
         }
 
-        if ((key === 'requestHeaders' || key === 'responseHeaders')) {
+        if (key === 'requestHeaders' || key === 'responseHeaders') {
             return (
                 <div className='headers'>
                     <ul className='headerList'>

--- a/src/components/EventMetaDataTable.jsx
+++ b/src/components/EventMetaDataTable.jsx
@@ -67,10 +67,20 @@ export default class EventMetaDataTable extends PureComponent {
             return String(value);
         }
 
-        if ((key === 'requestHeaders' || key === 'responseHeaders') && /^browser:http/.test(eventType)) {
-            return value.map((map, i) => (
-                <div className="line" key={i}>{map.get('name') + ': ' + map.get('value')}</div>
-            ));
+        if ((key === 'requestHeaders' || key === 'responseHeaders')) {
+            return (
+                <div className='headers'>
+                    <ul className='headerList'>
+                        {value.map((map, i) => (
+                            <li className='headerListItem' key={i}>
+                                <span className="key">{map.get('name') + ': '}</span>
+                                {map.get('value')}
+                            </li>
+                        ))
+                        }
+                    </ul>
+                </div>
+            );
         }
 
         if (value.toJS) { // Immutable.js

--- a/src/components/style/EventDetails.less
+++ b/src/components/style/EventDetails.less
@@ -36,7 +36,7 @@
 
         > .EventMetaDataTable {
             padding: @padding;
-            width: ~ "calc(100% - @{PerformrRunnerResultGraph_leftColumnWidth} - @{padding} * 2})";
+            width: ~ "calc(100% - @{PerformrRunnerResultGraph_leftColumnWidth} - @{padding} * 2)";
             flex: 0 0 auto;
         }
     }

--- a/src/components/style/EventMetaDataTable.less
+++ b/src/components/style/EventMetaDataTable.less
@@ -21,7 +21,7 @@
                             list-style-type: none;
                             > li {
                                 > span {
-                                font-weight: bold;
+                                    font-weight: bold;
                                 }
                             }
                         }

--- a/src/components/style/EventMetaDataTable.less
+++ b/src/components/style/EventMetaDataTable.less
@@ -16,6 +16,18 @@
                     line-height: 1.1rem;
                     padding-bottom: 0.4rem;
 
+                    > div {
+                        > ul {
+                            list-style-type: none;
+                            > li {
+                                > span {
+                                font-weight: bold;
+                                }
+                            }
+                        }
+
+                    }
+                
                     > .line {
                         text-indent: 3em hanging;
                     }

--- a/src/components/style/EventMetaDataTable.less
+++ b/src/components/style/EventMetaDataTable.less
@@ -20,16 +20,15 @@
                         > ul {
                             list-style-type: none;
                             > li {
-                                > span {
+                                > .key {
                                     font-weight: bold;
+                                }
+                                > .value {
+                                    white-space: pre-wrap;
                                 }
                             }
                         }
 
-                    }
-                
-                    > .line {
-                        text-indent: 3em hanging;
                     }
 
                     > .viewScreenshotButton {


### PR DESCRIPTION
In the breakdown details pane the request and response headers were shown as JSON. To improve this the part of checking on eventType was removed. The details are now shown in a list item where the key name is shown in the font bold. Also fix a typo that caused horizontal scrollbars in the meta data table